### PR TITLE
Use the same branch when PR already exists

### DIFF
--- a/internal/helm/index.go
+++ b/internal/helm/index.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"errors"
 	"github.com/hashicorp/go-version"
 	"golang.org/x/xerrors"
 	helmrepo "helm.sh/helm/v3/pkg/repo"
@@ -12,7 +13,7 @@ import (
 )
 
 var (
-	ErrAlreadyUpToDate = xerrors.New("current version is already up-to-date")
+	ErrAlreadyUpToDate = errors.New("current version is already up-to-date")
 )
 
 type chartRepo struct {

--- a/internal/setter/setter.go
+++ b/internal/setter/setter.go
@@ -1,6 +1,7 @@
 package setter
 
 import (
+	"errors"
 	"fmt"
 	"golang.org/x/xerrors"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -8,6 +9,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/fieldmeta"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/setters2"
+)
+
+var (
+	ErrMarkNotFound = errors.New("no marks were found")
 )
 
 func init() {
@@ -39,6 +44,10 @@ func Execute(path string, key client.ObjectKey, value string) error {
 
 	if err := p.Execute(); err != nil {
 		return xerrors.Errorf("failed to execute setter: %+w", err)
+	}
+
+	if instance.Count == 0 {
+		return ErrMarkNotFound
 	}
 
 	return nil


### PR DESCRIPTION
Previous branch names  include next chart version, but this would result in too many PRs in case the PR stays long.
In this PR, we use the same branch when the same HelmRelease is updated repeatedly.
